### PR TITLE
gemfile: add source URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
 gem 'octokit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,15 @@
 GEM
+  remote: https://rubygems.org/
   specs:
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    faraday (1.0.0)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     multipart-post (2.1.1)
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)


### PR DESCRIPTION
otherwise a fresh `bundle install` gives
```
=> bundle install
Your Gemfile has no gem server sources. If you need gems that are
not already on your machine, add a line like this to your Gemfile:
source 'https://rubygems.org'
```